### PR TITLE
Fix for Incompatible Data Type Setting in DataFrame Columns

### DIFF
--- a/Normalized_Decision_Matrix.py
+++ b/Normalized_Decision_Matrix.py
@@ -1,13 +1,17 @@
 from Normalization import *
 
 def Normalize_Decision_Matrix(Decision_Matrix, Attribute_Type, Normal_Method):
+    Decision_Matrix = Decision_Matrix.astype(float)
+    
     for i in range(0, len(Attribute_Type)):
         if Attribute_Type[i] == 1:
             Type = "profit"
         elif Attribute_Type[i] == 0:
             Type = "cost"
         else:
-            "Please, fill the correct attribute type"
+            print("Please, fill the correct attribute type")
+        
+        normalized_values = Normal_Method(Decision_Matrix.iloc[:, i], Type)
+        Decision_Matrix.iloc[:, i] = normalized_values
 
-        Decision_Matrix.iloc[:, i] = Normal_Method(Decision_Matrix.iloc[:, i], Type)
     return Decision_Matrix


### PR DESCRIPTION
## Description
Encountered a FutureWarning issue while executing the TOPSIS method implementation from your repository. The warning occurs when the code attempts to assign floating-point values to a DataFrame column initially inferred as integer type. This behavior is deprecated in pandas and will raise an error in future versions. The warning specifically mentions that setting an item with an incompatible dtype is deprecated and advises explicitly casting to a compatible dtype first.

## Changes
To address this issue, I propose a modification in the Normalize_Decision_Matrix function within the Normalized_Decision_Matrix.py file. The solution ensures that the DataFrame columns are explicitly converted to a float data type before any assignment operation that involves floating-point values. This approach prevents the FutureWarning by ensuring data type compatibility across all operations within the function.